### PR TITLE
Feature/return if errors on returning interaction

### DIFF
--- a/lib/makwa/interaction.rb
+++ b/lib/makwa/interaction.rb
@@ -2,14 +2,7 @@
 
 module Makwa
   class Interaction < ::ActiveInteraction::Base
-    class Interrupt < StandardError
-      attr_reader :errors
-
-      def initialize(errors)
-        super
-
-        @errors = errors
-      end
+    class Interrupt < Object.const_get("::ActiveInteraction::Interrupt")
     end
 
     #
@@ -82,19 +75,6 @@ module Makwa
     def indent
       lvl = [0, calling_interactions.count].max
       "  " * lvl
-    end
-
-    private
-
-    def run
-      return self.result = nil unless valid?
-
-      self.result = run_callbacks(:execute) do
-        execute
-      rescue ::Makwa::Interaction::Interrupt => e
-        errors.backtrace = e.errors.backtrace || e.backtrace
-        errors.merge!(e.errors)
-      end
     end
   end
 end

--- a/lib/makwa/returning_interaction.rb
+++ b/lib/makwa/returning_interaction.rb
@@ -48,7 +48,6 @@ module Makwa
       return result.tap { |r| r.errors.merge!(errors) } if errors_any?
 
       # Otherwise run the body of the interaction (along with any callbacks) ...
-      # run_callbacks(:execute_returning) { execute_returning }
       run_callbacks(:execute_returning) do
         execute_returning
       rescue ::Makwa::Interaction::Interrupt


### PR DESCRIPTION
Rescuing from `ActiveInteraction::Interrupt` in the returning interaction was ugly:

```ruby
rescue(Object.get_const("::ActiveInteraction::Interrupt"))
```

So I created a custom `Makwa::Interaction::Interrupt` error class, and that can be used in both of the Makwa interaction types. **Is there a way to make that protected** (vs. private)? Anyway, with that, the above line can be:

```ruby
rescue ::Makwa::Interaction::Interrupt
```

This PR also adds a test with several assertions for using `#return_if_errors!` in a ReturningInteraction.