### PR TITLE
Correctly ignore the `returning` filter

### DIFF
--- a/lib/makwa/returning_interaction.rb
+++ b/lib/makwa/returning_interaction.rb
@@ -46,10 +46,11 @@ module Makwa
       # Run validations (explicitly, don't rely on #valid?)
       validate
       if errors_any?
+        return_filter = self.class.instance_variable_get(:@return_filter)
         # Add errors and values to the result object (so that the form can render them) and return the result object
         return result
             .tap { |r| r.errors.merge!(errors) }
-            .tap { |r| r.assign_attributes(inputs.except(@return_filter)) }
+            .tap { |r| r.assign_attributes(inputs.except(return_filter)) }
       end
 
       # Otherwise run the body of the interaction (along with any callbacks) ...


### PR DESCRIPTION
# Correctly Ignore the `returning` filter

When an error happens before hitting `execute_returning` (with the inputs or validations), we assign the inputs to the `returning` filter so that the changes made by the user will be available in the returned record for use in the form. The returning input itself needs to be ignored, and previously this was not happening. This PR fixes the problem.