### PR TITLE
Use string for Object.const_get and nested constant

### DIFF
--- a/lib/makwa/interaction.rb
+++ b/lib/makwa/interaction.rb
@@ -2,7 +2,7 @@
 
 module Makwa
   class Interaction < ::ActiveInteraction::Base
-    class Interrupt < Object.const_get(:"::ActiveInteraction::Interrupt")
+    class Interrupt < Object.const_get("::ActiveInteraction::Interrupt")
     end
 
     #


### PR DESCRIPTION
# Description
This causes an error in Niiwin when `v5.2.0` of `active_interaction` is used:
```“makwa/interaction.rb:5:in `const_get’: wrong constant name ::ActiveInteraction::Interrupt (NameError)”```

Seems like symbols can't be used for nested constants in `Object.get_const`:
https://bugs.ruby-lang.org/issues/12319

Bug was introduced in a recent change:
https://github.com/animikii/makwa/commit/2470b1c66b61e2f5f0eb035e1412271d3217a886#diff-203f621eda84f0d2ccb32a288d6145df75313ea1b6efd2ac12bfb375f31658c6R5